### PR TITLE
patch-select

### DIFF
--- a/packages/support/resources/js/utilities/select.js
+++ b/packages/support/resources/js/utilities/select.js
@@ -50,7 +50,7 @@ export class Select {
         livewireId = null,
         statePath = null,
         onStateChange = () => {},
-    }) {
+      }) {
         this.element = element
         this.options = options
         this.originalOptions = JSON.parse(JSON.stringify(options)) // Keep a copy of original options
@@ -99,6 +99,9 @@ export class Select {
 
         this.render()
         this.setUpEventListeners()
+
+        this.typeaheadQuery = '' // Store typed characters
+        this.typeaheadTimeout = null // Timeout to clear typed characters
 
         if (this.isAutofocused) {
             this.selectButton.focus()
@@ -760,7 +763,7 @@ export class Select {
         removeButton.setAttribute(
             'aria-label',
             'Remove ' +
-                (this.isHtmlAllowed ? label.replace(/<[^>]*>/g, '') : label),
+            (this.isHtmlAllowed ? label.replace(/<[^>]*>/g, '') : label),
         )
 
         removeButton.addEventListener('click', (event) => {
@@ -1091,6 +1094,18 @@ export class Select {
 
     // Handle keyboard events for the select button
     handleSelectButtonKeydown(event) {
+        // If the select is disabled, don't handle keyboard events
+        if (this.isDisabled) {
+            return
+        }
+
+        // Handle printable characters for typeahead search when the dropdown is closed
+        if (!this.isOpen && event.key.length === 1 && !event.ctrlKey && !event.altKey && !event.metaKey) {
+            event.preventDefault()
+            this.handleTypeahead(event.key)
+            return
+        }
+
         switch (event.key) {
             case 'ArrowDown':
                 event.preventDefault()
@@ -1139,6 +1154,97 @@ export class Select {
                 }
                 break
         }
+    }
+
+    handleTypeahead(char) {
+        // Clear any existing timeout
+        if (this.typeaheadTimeout) {
+            clearTimeout(this.typeaheadTimeout)
+        }
+
+        // Add the character to the query
+        this.typeaheadQuery += char.toLowerCase()
+
+        // Find matching option
+        const matchingOption = this.findMatchingOption(this.typeaheadQuery)
+
+        if (matchingOption) {
+            // Select the matching option
+            this.selectOption(matchingOption.value)
+        }
+
+        // Clear the typeahead query after 1 second of inactivity
+        this.typeaheadTimeout = setTimeout(() => {
+            this.typeaheadQuery = ''
+        }, 1000)
+    }
+
+    findMatchingOption(query) {
+        // Search through all options (including grouped options)
+        for (const option of this.options) {
+            if (option.options && Array.isArray(option.options)) {
+                // Search in the option group
+                for (const groupOption of option.options) {
+                    // Skip disabled options
+                    if (groupOption.isDisabled) {
+                        continue
+                    }
+
+                    const label = groupOption.label.toLowerCase()
+
+                    // Check if the label starts with the query
+                    if (label.startsWith(query)) {
+                        return groupOption
+                    }
+                }
+            } else {
+                // Skip disabled options
+                if (option.isDisabled) {
+                    continue
+                }
+
+                const label = option.label.toLowerCase()
+
+                // Check if the label starts with the query
+                if (label.startsWith(query)) {
+                    return option
+                }
+            }
+        }
+
+        // If no match found with startsWith, try includes for partial matches
+        for (const option of this.options) {
+            if (option.options && Array.isArray(option.options)) {
+                // Search in the option group
+                for (const groupOption of option.options) {
+                    // Skip disabled options
+                    if (groupOption.isDisabled) {
+                        continue
+                    }
+
+                    const label = groupOption.label.toLowerCase()
+
+                    // Check if the label includes the query
+                    if (label.includes(query)) {
+                        return groupOption
+                    }
+                }
+            } else {
+                // Skip disabled options
+                if (option.isDisabled) {
+                    continue
+                }
+
+                const label = option.label.toLowerCase()
+
+                // Check if the label includes the query
+                if (label.includes(query)) {
+                    return option
+                }
+            }
+        }
+
+        return null
     }
 
     // Handle keyboard events within the dropdown
@@ -1295,8 +1401,8 @@ export class Select {
                 const normalizedFetched = Array.isArray(fetchedOptions)
                     ? fetchedOptions
                     : fetchedOptions && Array.isArray(fetchedOptions.options)
-                      ? fetchedOptions.options
-                      : []
+                        ? fetchedOptions.options
+                        : []
 
                 // Update options
                 this.options = normalizedFetched
@@ -1621,8 +1727,8 @@ export class Select {
                 const normalizedResults = Array.isArray(results)
                     ? results
                     : results && Array.isArray(results.options)
-                      ? results.options
-                      : []
+                        ? results.options
+                        : []
 
                 // Update options with search results
                 this.options = normalizedResults
@@ -2095,6 +2201,12 @@ export class Select {
         if (this.searchTimeout) {
             clearTimeout(this.searchTimeout)
             this.searchTimeout = null
+        }
+        
+        // Clear any pending typeahead timeout
+        if (this.typeaheadTimeout) {
+            clearTimeout(this.typeaheadTimeout)
+            this.typeaheadTimeout = null
         }
 
         // Remove the container element from the DOM

--- a/packages/support/resources/js/utilities/select.js
+++ b/packages/support/resources/js/utilities/select.js
@@ -50,7 +50,7 @@ export class Select {
         livewireId = null,
         statePath = null,
         onStateChange = () => {},
-      }) {
+    }) {
         this.element = element
         this.options = options
         this.originalOptions = JSON.parse(JSON.stringify(options)) // Keep a copy of original options
@@ -763,7 +763,7 @@ export class Select {
         removeButton.setAttribute(
             'aria-label',
             'Remove ' +
-            (this.isHtmlAllowed ? label.replace(/<[^>]*>/g, '') : label),
+                (this.isHtmlAllowed ? label.replace(/<[^>]*>/g, '') : label),
         )
 
         removeButton.addEventListener('click', (event) => {
@@ -1401,8 +1401,8 @@ export class Select {
                 const normalizedFetched = Array.isArray(fetchedOptions)
                     ? fetchedOptions
                     : fetchedOptions && Array.isArray(fetchedOptions.options)
-                        ? fetchedOptions.options
-                        : []
+                      ? fetchedOptions.options
+                      : []
 
                 // Update options
                 this.options = normalizedFetched
@@ -1727,8 +1727,8 @@ export class Select {
                 const normalizedResults = Array.isArray(results)
                     ? results
                     : results && Array.isArray(results.options)
-                        ? results.options
-                        : []
+                      ? results.options
+                      : []
 
                 // Update options with search results
                 this.options = normalizedResults

--- a/packages/support/resources/js/utilities/select.js
+++ b/packages/support/resources/js/utilities/select.js
@@ -100,9 +100,6 @@ export class Select {
         this.render()
         this.setUpEventListeners()
 
-        this.typeaheadQuery = '' // Store typed characters
-        this.typeaheadTimeout = null // Timeout to clear typed characters
-
         if (this.isAutofocused) {
             this.selectButton.focus()
         }
@@ -1133,10 +1130,6 @@ export class Select {
                 })
                 return
             }
-
-            // Not searchable: keep legacy typeahead behavior
-            this.handleTypeahead(event.key)
-            return
         }
 
         switch (event.key) {
@@ -1187,97 +1180,6 @@ export class Select {
                 }
                 break
         }
-    }
-
-    handleTypeahead(char) {
-        // Clear any existing timeout
-        if (this.typeaheadTimeout) {
-            clearTimeout(this.typeaheadTimeout)
-        }
-
-        // Add the character to the query
-        this.typeaheadQuery += char.toLowerCase()
-
-        // Find matching option
-        const matchingOption = this.findMatchingOption(this.typeaheadQuery)
-
-        if (matchingOption) {
-            // Select the matching option
-            this.selectOption(matchingOption.value)
-        }
-
-        // Clear the typeahead query after 1 second of inactivity
-        this.typeaheadTimeout = setTimeout(() => {
-            this.typeaheadQuery = ''
-        }, 1000)
-    }
-
-    findMatchingOption(query) {
-        // Search through all options (including grouped options)
-        for (const option of this.options) {
-            if (option.options && Array.isArray(option.options)) {
-                // Search in the option group
-                for (const groupOption of option.options) {
-                    // Skip disabled options
-                    if (groupOption.isDisabled) {
-                        continue
-                    }
-
-                    const label = groupOption.label.toLowerCase()
-
-                    // Check if the label starts with the query
-                    if (label.startsWith(query)) {
-                        return groupOption
-                    }
-                }
-            } else {
-                // Skip disabled options
-                if (option.isDisabled) {
-                    continue
-                }
-
-                const label = option.label.toLowerCase()
-
-                // Check if the label starts with the query
-                if (label.startsWith(query)) {
-                    return option
-                }
-            }
-        }
-
-        // If no match found with startsWith, try includes for partial matches
-        for (const option of this.options) {
-            if (option.options && Array.isArray(option.options)) {
-                // Search in the option group
-                for (const groupOption of option.options) {
-                    // Skip disabled options
-                    if (groupOption.isDisabled) {
-                        continue
-                    }
-
-                    const label = groupOption.label.toLowerCase()
-
-                    // Check if the label includes the query
-                    if (label.includes(query)) {
-                        return groupOption
-                    }
-                }
-            } else {
-                // Skip disabled options
-                if (option.isDisabled) {
-                    continue
-                }
-
-                const label = option.label.toLowerCase()
-
-                // Check if the label includes the query
-                if (label.includes(query)) {
-                    return option
-                }
-            }
-        }
-
-        return null
     }
 
     // Handle keyboard events within the dropdown
@@ -2258,12 +2160,6 @@ export class Select {
         if (this.searchTimeout) {
             clearTimeout(this.searchTimeout)
             this.searchTimeout = null
-        }
-
-        // Clear any pending typeahead timeout
-        if (this.typeaheadTimeout) {
-            clearTimeout(this.typeaheadTimeout)
-            this.typeaheadTimeout = null
         }
 
         // Remove the container element from the DOM

--- a/packages/support/resources/js/utilities/select.js
+++ b/packages/support/resources/js/utilities/select.js
@@ -1099,7 +1099,8 @@ export class Select {
             return
         }
 
-        // Handle printable characters for typeahead search when the dropdown is closed
+        // Handle printable characters: when searchable,
+        // open dropdown and use search input; otherwise, fall back to typeahead
         if (
             !this.isOpen &&
             event.key.length === 1 &&
@@ -1108,6 +1109,32 @@ export class Select {
             !event.metaKey
         ) {
             event.preventDefault()
+
+            if (this.isSearchable) {
+                // Open the dropdown and funnel the typed character into the search input
+                const char = event.key
+                Promise.resolve(this.openDropdown()).then(() => {
+                    if (!this.searchInput) return
+
+                    // Set the typed character as the initial search value
+                    this.searchInput.value = char
+                    this.searchQuery = char.toLowerCase()
+
+                    // Trigger the existing search logic
+                    this.handleSearch({ target: this.searchInput })
+
+                    // Focus the search input for continued typing
+                    this.searchInput.focus()
+
+                    try {
+                        const end = this.searchInput.value.length
+                        this.searchInput.setSelectionRange(end, end)
+                    } catch (_) {}
+                })
+                return
+            }
+
+            // Not searchable: keep legacy typeahead behavior
             this.handleTypeahead(event.key)
             return
         }
@@ -1255,6 +1282,30 @@ export class Select {
 
     // Handle keyboard events within the dropdown
     handleDropdownKeydown(event) {
+        // If it's a printable character and the select is searchable, redirect typing to the search input
+        if (
+            this.isSearchable &&
+            event.key.length === 1 &&
+            !event.ctrlKey &&
+            !event.altKey &&
+            !event.metaKey
+        ) {
+            event.preventDefault()
+            if (this.searchInput) {
+                if (document.activeElement !== this.searchInput) {
+                    this.searchInput.focus()
+                }
+                const newVal = this.searchInput.value + event.key
+                this.searchInput.value = newVal
+                this.searchQuery = newVal.trim().toLowerCase()
+                this.handleSearch({ target: this.searchInput })
+                try {
+                    const end = this.searchInput.value.length
+                    this.searchInput.setSelectionRange(end, end)
+                } catch (_) {}
+            }
+            return
+        }
         switch (event.key) {
             case 'ArrowDown':
                 event.preventDefault()

--- a/packages/support/resources/js/utilities/select.js
+++ b/packages/support/resources/js/utilities/select.js
@@ -1100,7 +1100,13 @@ export class Select {
         }
 
         // Handle printable characters for typeahead search when the dropdown is closed
-        if (!this.isOpen && event.key.length === 1 && !event.ctrlKey && !event.altKey && !event.metaKey) {
+        if (
+            !this.isOpen &&
+            event.key.length === 1 &&
+            !event.ctrlKey &&
+            !event.altKey &&
+            !event.metaKey
+        ) {
             event.preventDefault()
             this.handleTypeahead(event.key)
             return
@@ -2202,7 +2208,7 @@ export class Select {
             clearTimeout(this.searchTimeout)
             this.searchTimeout = null
         }
-        
+
         // Clear any pending typeahead timeout
         if (this.typeaheadTimeout) {
             clearTimeout(this.typeaheadTimeout)

--- a/packages/support/resources/js/utilities/select.js
+++ b/packages/support/resources/js/utilities/select.js
@@ -1096,8 +1096,7 @@ export class Select {
             return
         }
 
-        // Handle printable characters: when searchable,
-        // open dropdown and use search input; otherwise, fall back to typeahead
+        // Handle printable characters: when searchable, open dropdown and use search input
         if (
             !this.isOpen &&
             event.key.length === 1 &&


### PR DESCRIPTION
<!-- FILL OUT ALL RELEVANT SECTIONS, OR THE PULL REQUEST WILL BE CLOSED. -->

## Description

Hi @danharrin,

In Filament v3, when being focused on a searchable select but without opening, you could search by just writing the text, and the search dropdown would open and begin searching.
In Filament v4, the search only starts if the select searchable is open.

I'm adding the feature so that it searches like the v3 way of doing it, but first want to check if this was a decision made so that it works like v4.

I have a draft PR, I made the changes and then used AI to check the implementation, so probably there are some improvements to be made since I code in PHP and basically don't use JS since Livewire was released.

## Visual changes

<!-- Add screenshots/recordings of before and after. -->

## Functional changes

- [X] Code style has been fixed by running the `composer cs` command.
- [X] Changes have been tested to not break existing functionality.
- [X] Documentation is up-to-date.
